### PR TITLE
Update Dependencies via Dependable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,4 +33,4 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
-gem 'math24', '~> 2.0.0'
+gem 'math24', '~> 2.0.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,8 +40,9 @@ GEM
       tzinfo (~> 1.1)
     arel (7.1.4)
     builder (3.2.3)
-    byebug (9.0.6)
+    byebug (9.1.0)
     concurrent-ruby (1.0.5)
+    crass (1.0.2)
     diff-lcs (1.3)
     erubis (2.7.0)
     ffi (1.9.18)
@@ -51,7 +52,8 @@ GEM
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    loofah (2.0.3)
+    loofah (2.1.0)
+      crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.6.6)
       mime-types (>= 1.16, < 4)
@@ -60,11 +62,11 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
-    mini_portile2 (2.2.0)
+    mini_portile2 (2.3.0)
     minitest (5.10.3)
     nio4r (1.2.1)
-    nokogiri (1.8.0)
-      mini_portile2 (~> 2.2.0)
+    nokogiri (1.8.1)
+      mini_portile2 (~> 2.3.0)
     puma (3.6.2)
     rack (2.0.3)
     rack-test (0.6.3)
@@ -92,7 +94,7 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    rake (12.0.0)
+    rake (12.1.0)
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
@@ -121,7 +123,7 @@ GEM
     sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    sprockets-rails (3.2.0)
+    sprockets-rails (3.2.1)
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
@@ -139,7 +141,7 @@ PLATFORMS
 DEPENDENCIES
   byebug
   listen (~> 3.0.8)
-  math24 (~> 2.0.0)
+  math24 (~> 2.0.1)
   puma (~> 3.6.2)
   rails (~> 5.0.0.1, >= 5.0.0.1)
   rspec-rails
@@ -148,4 +150,4 @@ DEPENDENCIES
   tzinfo-data
 
 BUNDLED WITH
-   1.15.3
+   1.15.4


### PR DESCRIPTION
Update Dependencies via Dependable

## Dependency updates

| Gem | Previous Version | New Version | Source | Diff |
| --- | --- | --- | --- | --- |
| byebug | 9.0.6 | 9.1.0 | [deivid-rodriguez/byebug](https://github.com/deivid-rodriguez/byebug) | [view](https://github.com/deivid-rodriguez/byebug/compare/v9.0.6...v9.1.0) |

## Sub-dependency updates

| Gem | Previous Version | New Version | Source | Diff |
| --- | --- | --- | --- | --- |
| rake | 12.0.0 | 12.1.0 | [ruby/rake](https://github.com/ruby/rake) | [view](https://github.com/ruby/rake/compare/v12.0.0...v12.1.0) |
| mini_portile2 | 2.2.0 | 2.3.0 | Not Available | Not Available |
| nokogiri | 1.8.0 | 1.8.1 | [sparklemotion/nokogiri](https://github.com/sparklemotion/nokogiri) | [view](https://github.com/sparklemotion/nokogiri/compare/v1.8.0...v1.8.1) |
| loofah | 2.0.3 | 2.1.0 | [flavorjones/loofah](https://github.com/flavorjones/loofah) | Not Available |
| sprockets-rails | 3.2.0 | 3.2.1 | [rails/sprockets-rails](https://github.com/rails/sprockets-rails) | [view](http://github.com/rails/sprockets-rails/compare/v3.2.0...v3.2.1) |